### PR TITLE
Implement contact form handling

### DIFF
--- a/src/app/(app)/contacto/page.tsx
+++ b/src/app/(app)/contacto/page.tsx
@@ -102,7 +102,7 @@ export default function Page() {
           </div>
         </div>
         <form
-          action="#"
+          action="/api/contact"
           method="POST"
           className="px-6 pb-24 pt-20 sm:pb-32 lg:px-8 lg:py-48"
         >

--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -1,0 +1,21 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getPayload } from "payload";
+import config from "@payload-config";
+
+export async function POST(req: NextRequest) {
+  const formData = await req.formData();
+
+  const payload = await getPayload({ config });
+
+  await payload.create({
+    collection: "messages",
+    data: {
+      firstName: formData.get("first-name"),
+      lastName: formData.get("last-name"),
+      email: formData.get("email"),
+      phoneNumber: formData.get("phone-number"),
+    },
+  });
+
+  return NextResponse.redirect(new URL("/contacto", req.url));
+}

--- a/src/app/payload.config.ts
+++ b/src/app/payload.config.ts
@@ -4,6 +4,7 @@ import { lexicalEditor } from "@payloadcms/richtext-lexical";
 import { sqliteAdapter } from "@payloadcms/db-sqlite";
 import { buildConfig } from "payload";
 import { MainCollection, Media, NormalPages } from "@/collections/pages/main";
+import Messages from "@/collections/messages";
 
 export default buildConfig({
   editor: lexicalEditor(),
@@ -13,11 +14,11 @@ export default buildConfig({
       url:
         process.env.NEXT_PUBLIC_PAYLOAD_LIVE_PREVIEW_URL! ||
         "http://localhost:3000",
-      collections: ["pages", "media", "normal-pages"],
+      collections: ["pages", "media", "normal-pages", "messages"],
     },
   },
 
-  collections: [MainCollection, Media, NormalPages],
+  collections: [MainCollection, Media, NormalPages, Messages],
   secret: process.env.TURSO_AUTH_TOKEN!,
 
   plugins: [

--- a/src/collections/messages/index.ts
+++ b/src/collections/messages/index.ts
@@ -1,0 +1,31 @@
+import { CollectionConfig } from "payload";
+
+const Messages: CollectionConfig = {
+  slug: "messages",
+  admin: {
+    useAsTitle: "email",
+  },
+  fields: [
+    {
+      name: "firstName",
+      type: "text",
+      required: true,
+    },
+    {
+      name: "lastName",
+      type: "text",
+      required: true,
+    },
+    {
+      name: "email",
+      type: "email",
+      required: true,
+    },
+    {
+      name: "phoneNumber",
+      type: "text",
+    },
+  ],
+};
+
+export default Messages;


### PR DESCRIPTION
## Summary
- enable contact form submission via `/api/contact`
- store messages in a new PayloadCMS collection
- register the new collection with Payload
- update the contact page to post to the new route

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f543bd1c88324b4eaa65059ce4c3b